### PR TITLE
pre_call: ensure .hydra subdir exists before writing zen_config.yaml

### DIFF
--- a/ml_project_template/config.py
+++ b/ml_project_template/config.py
@@ -51,6 +51,7 @@ def pre_call(
     if verbose:
         logger.info(f"Saving outputs in {output_path}")
 
+    (output_path / ".hydra").mkdir(parents=True, exist_ok=True)
     save_as_yaml(root_config, output_path / ".hydra/zen_config.yaml")
 
     if (wandb_config := config.get(ConfigKeys.WANDB)) is not None:


### PR DESCRIPTION
get_output_dir() can point at HYDRA_OUTPUT_DIR rather than hydra's run dir, so the .hydra subdir may not exist yet.